### PR TITLE
点击事件问题

### DIFF
--- a/wavesidebar/src/main/java/com/gjiazhe/wavesidebar/WaveSideBar.java
+++ b/wavesidebar/src/main/java/com/gjiazhe/wavesidebar/WaveSideBar.java
@@ -235,6 +235,7 @@ public class WaveSideBar extends View {
                     invalidate();
                     return true;
                 } else {
+                    mCurrentIndex = -1;
                     return false;
                 }
 


### PR DESCRIPTION
不知道算不算个问题，
状况：列表页有点击事件并且跳转至新的activity ，然后finish掉activity，这时会调用onDraw方法，但是由于没有清除mCurrentIndex，会造成正在滑动的假象。
解决方法: 再不包含字符的点击事件外重置mCurrentIndex =-1。
